### PR TITLE
Corrections for conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,51 @@
 Budget and projects extension
 =============================
 
-[Issue #400](https://github.com/open-contracting/standard/issues/400) raises the importance of distinguishing project information from budget information.
+In the core OCDS, project information is nested within the ```budget``` building block. However, in some cases, budget management, and project management systems are separate, and it may be important to separately specify:
 
-This is also important for the PPP extension to OCDS.
+* The amount reserved in the budget for a specific contracting process; 
+
+* The project the contract relates to, and the total value of that project; 
+
+This is particularly important in cases of Public Private Partnership projects, or large infrastructure projects, where users may wish to track all the contracting processes related to a large-scale project, and to understand the individual contracts in the context of their contracting process and overall project values. 
+
+This extension introduces a ```project``` object into the ```planning``` section. 
+
+In the OCDS for PPPs profile, this is further extended with sector and location classifications. 
+
+## Example
+
+```json
+{
+  "planning": {
+    "project": {
+      "title": "Example PPP",
+      "description": "The Example PPP project will guarantee the installation of a wholesale shared network that allows the provision of telecommunications services by current and future operators.",
+      "id": "example_ppp",
+      "uri": "http://communications.gov.example/projects/example_ppp",
+      "totalValue": {
+        "amount": 600000000,
+        "currency": "USD"
+      }
+    }
+  }
+}
+```
+
+## Documentation
+
+```eval_rst
+.. extensiontable::
+   :extension: budget_project
+   :exclude_definitions: 
+```
+
+
+
+## ChangeLog
+
+**2017-07-08**
+
+* Updated version to maintain conformance with OCDS 1.1, removing the properties in the extension that deleted ```planning/budget/project``` and ```planning/budget/projectID```.
+
+* Removing unneccessary mergeStrategy and pattern property schema elements

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,9 @@
 {
   "name": "Budget and Project Updates",
-  "description": "Separating budget and project information based on https://github.com/open-contracting/standard/issues/400 and requirements of the PPP extension.",
-  "compatibility": ">=1.0.0",
+  "description": "This extension introduces a projects block in 'planning' which can be used to give total project value, and provide project-level information, alongside existing fields in the planning/budget section for details of the budget allocated to this specific contracting process.",
+  "compatibility": ">=1.1.0",
+  "documentationUrl": {
+    "en": "https://github.com/open-contracting/ocds_budget_projects_extension/"
+   },
   "dependencies": []
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -14,7 +14,6 @@
       "properties": {
         "id": {
           "description": "An externally provided identifier for the project. This might be drawn from a projects register, or may be based on the canonical version of a project name. Project IDs should be unique to a publisher. URIs can be used. ",
-          "mergeStrategy": "ocdsVersion",
           "type": [
             "string",
             "null"
@@ -23,7 +22,6 @@
         "title": {
           "title": "Project Title",
           "description": "The name of the project to which this contracting process relates. Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. ",
-          "mergeStrategy": "ocdsVersion",
           "type": [
             "string",
             "null"
@@ -32,7 +30,6 @@
         "description": {
           "title": "Project description",
           "description": "A short free text description of the project.",
-          "mergeStrategy": "ocdsVersion",
           "type": [
             "string",
             "null"
@@ -45,7 +42,6 @@
         "uri": {
           "title": "Linked project information",
           "description": "A URI pointing to further information about this project.",
-          "mergeStrategy": "ocdsVersion",
           "type": [
             "string",
             "null"
@@ -54,19 +50,13 @@
         }
       },
       "patternProperties": {
-        "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
           "type": [
             "string",
             "null"
           ]
         },
-        "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+        "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
           "type": [
             "string",
             "null"
@@ -91,8 +81,12 @@
         "amount": {
           "description": "The total value of budget allocations for this contracting process. The budget breakdown extension can be used to provide data for multiple budget sources, or to split the budget by years or other periods. "
         },
-        "project": null,
-        "projectID": null,
+        "project": {
+          "description": "The name of the project that through which this contracting process is funded. Detailed information should be provided in the extended projectDetail section."
+        },
+        "projectID": {
+          "description": "An external identifier for the project that this contracting process forms part of. Required for legacy compatibility with OCDS core."
+        },
         "uri": {
           "description": "A URI pointing directly to records about the related budget for this contracting process. Where possible this URI should return machine and human-readable representations of the data."
         }


### PR DESCRIPTION
The earlier copy of this extension set a number of elements of OCDS core to null.

Extensions should not remove fields, so I've updated the extension to only update the definitions of the elements. 

I've also removed mergeStrategies that were not needed, and have updated the readme and example. 