### PR TITLE
Move Project into its own definition, for re-use by other extensions

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -3,66 +3,68 @@
     "Planning": {
       "properties": {
         "project": {
-          "type": [
-            "object",
-            "null"
-          ],
           "title": "Project information",
           "description": "The project section can be used to describe the relationship between this contracting process and a project or programme of work.",
-          "properties": {
-            "id": {
-              "title": "Project identifier",
-              "description": "An externally provided identifier for the project. This might be drawn from a projects register, or may be based on the canonical version of a project name. Project IDs should be unique to a publisher. URIs can be used. ",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "title": {
-              "title": "Project title",
-              "description": "The name of the project to which this contracting process relates. Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. ",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "description": {
-              "title": "Project description",
-              "description": "A short free text description of the project.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "totalValue": {
-              "title": "Total project value",
-              "description": "The total anticipated value of the project over it's lifetime. ",
-              "$ref": "#/definitions/Value"
-            },
-            "uri": {
-              "title": "Linked project information",
-              "description": "A URI pointing to further information about this project.",
-              "type": [
-                "string",
-                "null"
-              ],
-              "format": "uri"
-            }
-          },
-          "patternProperties": {
-            "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          }
+          "$ref": "#/definitions/Project"
+        }
+      }
+    },
+    "Project": {
+      "title": "Project information",
+      "description": "A project or programme of work.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "title": "Project identifier",
+          "description": "An externally provided identifier for the project. This might be drawn from a projects register, or may be based on the canonical version of a project name. Project IDs should be unique to a publisher. URIs can be used. ",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "title": "Project title",
+          "description": "The name of the project to which this contracting process relates. Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. ",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "title": "Project description",
+          "description": "A short free text description of the project.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "totalValue": {
+          "title": "Total project value",
+          "description": "The total anticipated value of the project over it's lifetime. ",
+          "$ref": "#/definitions/Value"
+        },
+        "uri": {
+          "title": "Linked project information",
+          "description": "A URI pointing to further information about this project.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }


### PR DESCRIPTION
This, in effect, reverts #13. It wasn't anticipated at that time that other extensions would need arrays of projects, for which a common definition is useful.