### PR TITLE
Rename to Project extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Budget and projects extension
+# Project extension
 
 In the core OCDS, project information is nested within the `budget` building block. However, in some cases, budget management, and project management systems are separate, and it may be important to separately specify:
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Budget and Projects"
+    "en": "Project"
   },
   "description": {
     "en": "Adds a project object to the planning object to describe the project to which the contracting process is related, including the total value of the project (not to be confused with the total value of the contracting process)."


### PR DESCRIPTION
closes https://github.com/open-contracting/ocds-extensions/issues/103

When this is merged we should also change the repository name and the extension explorer link.